### PR TITLE
can: dbc.cc: Include <iterator>

### DIFF
--- a/can/dbc.cc
+++ b/can/dbc.cc
@@ -8,6 +8,7 @@
 #include <vector>
 #include <mutex>
 #include <cstring>
+#include <iterator>
 
 #include "common.h"
 #include "common_dbc.h"


### PR DESCRIPTION
fixes: `scons` on Arch based systems

We are using `std::ostream_iterator` which is taken from the <iterator> header

Signed-off-by: Gunwant Jain <mail@wantguns.dev>